### PR TITLE
[Fix] 충돌 해결 및 CommonInput 컴포넌트에 타입 추가

### DIFF
--- a/src/components/atoms/input/common/CommonInput.tsx
+++ b/src/components/atoms/input/common/CommonInput.tsx
@@ -1,14 +1,19 @@
 import classNames from 'classnames/bind';
-import { HTMLInputTypeAttribute, PropsWithChildren, ReactNode } from 'react';
+import {
+  HTMLInputTypeAttribute,
+  InputHTMLAttributes,
+  PropsWithChildren,
+  ReactNode,
+} from 'react';
 import { FieldErrors, RegisterOptions, UseFormRegister } from 'react-hook-form';
 import styles from './commonInput.module.scss';
 
 const cn = classNames.bind(styles);
 
-export interface CommonInputProps {
+export interface CommonInputProps
+  extends InputHTMLAttributes<HTMLInputElement> {
   errors: FieldErrors;
   register: UseFormRegister<any>;
-  name?: string;
   registerOptions?: RegisterOptions;
 }
 

--- a/src/components/molecules/input/CreateDoItYourselfTag.tsx
+++ b/src/components/molecules/input/CreateDoItYourselfTag.tsx
@@ -1,19 +1,7 @@
-<<<<<<< HEAD
-import { useState } from 'react';
-import styles from './createDoItYourselfTag.module.scss';
-<<<<<<< HEAD
-import ChipTag from '@/components/atoms/chipTag/ChipTag';
-import CreateDoItYourselfInput from '@/components/atoms/input/createDoItYourselfCommonInput/CreateDoItYourselfInput';
-=======
-import CreateDoItYourselfInput from '@/components/atoms/input/CreateDoItYourselfInput';
-import ChipTag from '@/components/atoms/chipTag/ChipTag';
->>>>>>> ffaae27 ([Feat] 할 일 페이지 atoms 구현 (#18))
-=======
 import ChipTag from '@/components/atoms/chipTag/ChipTag';
 import CreateDoItYourselfInput from '@/components/atoms/input/createDoItYourselfCommonInput/CreateDoItYourselfInput';
 import { useState } from 'react';
 import styles from './createDoItYourselfTag.module.scss';
->>>>>>> aa651f3b8199386f117015637dc75a2fce5440a3
 
 const colors: Array<'orange' | 'pink' | 'blue' | 'green'> = [
   'orange',

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -24,6 +24,7 @@
 
 * {
   box-sizing: border-box;
+  font-size: 1.6rem;
 }
 
 html {
@@ -39,11 +40,7 @@ body {
 }
 
 body,
-<<<<<<< HEAD
-input,
-=======
 input:not([type='checkbox']),
->>>>>>> aa651f3b8199386f117015637dc75a2fce5440a3
 textarea,
 a {
   all: unset;


### PR DESCRIPTION
### 이슈번호
closed #46


### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 버그 수정

### 변경 사항
- 머지 충돌 해결(`globals.css`, `CreateDoItYourselfTag.tsx`)
- `CommonInput.tsx` 컴포넌트에 타입 추가하여 defaultValue, value 등을 설정하도록 했습니다.

### 반영 브랜치
`46-bug-pr-41-충돌난-상태로-병합된-컴포넌트들-수정-및-타입스크립트-수정` -> `develop`

